### PR TITLE
Add Wellcome Library root collection

### DIFF
--- a/iiif-universe.json
+++ b/iiif-universe.json
@@ -38,6 +38,11 @@
       "@id": "http://digital.library.villanova.edu/Collection/vudl:3/IIIF",
       "@type": "sc:Collection",
       "label": "Digital Library @ Villanova University"
+    },
+    {
+      "@id": "http://wellcomelibrary.org/service/collections/",
+      "@type": "sc:Collection",
+      "label": "Wellcome Library"
     }
   ]
 }


### PR DESCRIPTION
Wellcome Library root collection (~90,000 manifests, ~13m images at time of writing)
