### PR TITLE
Add Biblissima top collection

### DIFF
--- a/iiif-universe.json
+++ b/iiif-universe.json
@@ -15,11 +15,6 @@
       "label": "Stanford"
     },
     {
-      "@id": "https://graph.global/static/data/universes/iiif/biblissima.json",
-      "@type": "sc:Collection",
-      "label": "Biblissima"
-    },
-    {
       "@id": "https://graph.global/static/data/universes/iiif/e-codices.json",
       "@type": "sc:Collection",
       "label": "e-codices"
@@ -49,10 +44,16 @@
       "@type": "sc:Collection",
       "label": "The Internet Archive Universal Collection"
     },
-        {
+    {
       "@id": "http://iiif.bodleian.ox.ac.uk/iiif/collection/All",
       "@type": "sc:Collection",
       "label": "Bodleian Library, Oxford"
+    },
+    {
+      "@id": "http://biblissima.fr/iiif/collection/top",
+      "@type": "sc:Collection",
+      "label": "Biblissima IIIF Collections",
+      "description": "Collections of IIIF Manifests from Biblissima's image repositories"
     }
   ]
 }


### PR DESCRIPTION
... and remove old biblissima.json collection (with out-of-date Biblissima manifests, now exposed directly by Gallica).

More details about these collections in this post on iiif-discuss (October 14th 2016): https://groups.google.com/forum/#!topic/iiif-discuss/m4Rn755ZFXc
