### PR TITLE
Endpoint cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages'
 gem 'faraday'
+gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,8 @@ GEM
     execjs (2.7.0)
     faraday (0.17.0)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
     ffi (1.11.1)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
@@ -244,6 +246,7 @@ PLATFORMS
 
 DEPENDENCIES
   faraday
+  faraday_middleware
   github-pages
 
 BUNDLED WITH

--- a/iiif-universe.json
+++ b/iiif-universe.json
@@ -5,17 +5,22 @@
   "label": "IIIF Universe",
   "collections": [
     {
+      "@id": "http://manifests.ydc2.yale.edu/manifest",
+      "@type": "sc:Collection",
+      "label": "Yale"
+    },    
+    {
       "@id": "https://graph.global/static/data/universes/iiif/stanford.json",
       "@type": "sc:Collection",
       "label": "Stanford"
     },
     {
-      "@id": "http://www.e-codices.unifr.ch/metadata/iiif/collection.json",
+      "@id": "https://www.e-codices.unifr.ch/metadata/iiif/collection.json",
       "@type": "sc:Collection",
       "label": "e-codices"
     },
     {
-      "@id": "https://scta.info/iiif/scta/collection",
+      "@id": "http://scta.info/iiif/scta/collection",
       "@type": "sc:Collection",
       "label": "Sentences Commentary Text Archive"
     },
@@ -42,7 +47,7 @@
       "description": "Collections of IIIF Manifests from Biblissima's image repositories"
     },
     {
-      "@id": "http://iiif.durham.ac.uk/manifests/trifle/collection/index",
+      "@id": "https://iiif.durham.ac.uk/manifests/trifle/collection/index",
       "@type": "sc:Collection",
       "label": "Durham University IIIF Collections"
     },

--- a/validate.rb
+++ b/validate.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'faraday'
+require 'faraday_middleware'
 require 'pp'
 
 failing = false
@@ -9,7 +10,11 @@ universe = JSON.parse(File.read('iiif-universe.json'))
 
 universe['collections'].each do |collection|
   begin
-    response = Faraday.head(collection['@id'])
+    response = Faraday.new(collection['@id']) do |b|
+      b.use FaradayMiddleware::FollowRedirects
+      b.adapter :net_http
+    end .head
+
     if response.status != 200
       failing = true
       $stderr.puts "Error validating: #{collection['label']}"


### PR DESCRIPTION
Further endpoint fixes (see #18).

A couple more changes to the ones already made. I also changed the validation script to follow redirects because there is one endpoint where I think the right url to use is one which redirects. All these should pass validation.

 * Restored Yale. I think it can stay in as it does work even if in http only. 
 * Changed e-codices to use https. Internally it uses https so I think that is the right choice for this one. It also redirects http to https, though interestingly this only happens when you access it in a web browser and not when you validate the endpoint with Faraday.
 * Changed Sentences Commentary Text Archive back to http. It will get redirected to https but I think http is the better choice here. Otherwise iiif-universe.json would have a collection with id that uses https but when you access that you get a collection that has id with http, thus not technically the same collection. 
 * Changed Durham to use https again. We had a certificate issue which tripped up the validation which is probably why you changed it to http. Our certificate is fixed now and https works properly and is the preferred way to access the endpoint.